### PR TITLE
Reduce token usage by limiting the number of generated response

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -167,6 +167,9 @@ func (s Session) callLLM(ctx context.Context, lastCall bool) (*llms.ContentChoic
 
 	options := []llms.CallOption{
 		llms.WithTools(s.mcpClients.GetTools()),
+		// Limit generated responses to 1 to save tokens.
+		llms.WithN(1),
+		llms.WithCandidateCount(1),
 	}
 
 	resp, err := s.llm.GenerateContent(ctx, s.messages, options...)


### PR DESCRIPTION
Reduce token usage by limiting the number of generated responses to 1.